### PR TITLE
Support Pipenv & Python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__/
 /wiki/
 /website/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ branches:
 
 before_install:
   - pip install --upgrade pip
-  - pip install coverage codecov coveralls
+  - pip install pipenv
+  - pipenv run python --version
 
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: pipenv install --dev
 
 #before_script:
   #- cp -a ./tests "$TRAVIS_BUILD_DIR"
@@ -34,21 +35,21 @@ notifications:
 
 # command to run tests
 script:
-  - coverage run --source=imapfw,imapfw.py -p -m imapfw.edmp
-  - coverage run --source=imapfw,imapfw.py -p -m imapfw.mmp.manager
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -h
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py noop
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -c multiprocessing unitTests
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -c threading unitTests
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all noop
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all testRascal
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all examine
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c multiprocessing syncAccounts -a AccountA
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c threading syncAccounts -a AccountA
-  - coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c threading syncAccounts -a AccountA -a AccountA -a AccountA
-  - coverage combine .coverage*
+  - pipenv run coverage run --source=imapfw,imapfw.py -p -m imapfw.edmp
+  - pipenv run coverage run --source=imapfw,imapfw.py -p -m imapfw.mmp.manager
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -h
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py noop
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -c multiprocessing unitTests
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -c threading unitTests
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all noop
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all testRascal
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all examine
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c multiprocessing syncAccounts -a AccountA
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c threading syncAccounts -a AccountA
+  - pipenv run coverage run --source=imapfw,imapfw.py -p ./imapfw.py -r ./tests/syncaccounts.1.rascal -d all -c threading syncAccounts -a AccountA -a AccountA -a AccountA
+  - pipenv run coverage combine .coverage*
 
 after_success:
-  - coveralls
-  - codecov
+  - pipenv run coveralls
+  - pipenv run codecov
 # vim: expandtab ts=2 :

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.6" # currently points to 3.6-dev
+  - "3.6-dev" # 3.6 development branch
+  # - "nightly" # disabled because testing against unstable yields to many false positives
   #- "pypy3"  # won't work since it implements Python 3.2.5.
 
 branches:
   only:
     - master
-    - coverage
     - next
-    - travis # Let testing travis configuration.
+    - support_python_3.6
 
 before_install:
   - pip install --upgrade pip

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+typing = "*"
+
+[dev-packages]
+codecov = "*"
+coverage = "*"
+coveralls = "*"
+
+[requires]
+python_version = "3"
+typing = { version = "*", markers = "python_version < '3.5'" }

--- a/Pipfile
+++ b/Pipfile
@@ -12,5 +12,5 @@ coverage = "*"
 coveralls = "*"
 
 [requires]
-python_version = "3"
+python_version = ">=3.4"
 typing = { version = "*", markers = "python_version < '3.5'" }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,134 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2a7987866090269774791c737561320c6d0256dea7c9f2d21adb8383f2bde038"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3",
+            "typing": {
+                "markers": "python_version < '3.5'",
+                "version": "*"
+            }
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "typing": {
+            "hashes": [
+                "sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf",
+                "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
+                "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
+            ],
+            "index": "pypi",
+            "version": "==3.6.4"
+        }
+    },
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+            ],
+            "version": "==2018.1.18"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "codecov": {
+            "hashes": [
+                "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
+                "sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4"
+            ],
+            "index": "pypi",
+            "version": "==2.0.15"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
+            ],
+            "index": "pypi",
+            "version": "==4.5.1"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:32569a43c9dbc13fa8199247580a4ab182ef439f51f65bb7f8316d377a1340e8",
+                "sha256:664794748d2e5673e347ec476159a9d87f43e0d2d44950e98ed0e27b98da8346"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+            ],
+            "version": "==2.6"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "version": "==2.18.4"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-typing; python_version < '3.5'


### PR DESCRIPTION
This PR migrates from `requirements.txt` to [Pipenv](https://docs.pipenv.org/) to enable a better development workflow. Also bump Travis tests to Python 3.6 

### Peers review

Trick to [fetch the pull request](https://help.github.com/articles/checking-out-pull-requests-locally): there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch origin pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character 'x': `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).

### References

### Additional information


